### PR TITLE
make sure the npm is the latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
   - "0.10"
   - "0.11"
 before_install:
+  - npm install -g npm
   - npm install -g grunt-cli


### PR DESCRIPTION
the default npm version comes with `nvm use 0.8` is outdated, reinstall npm to make sure the npm is the latest one. 
One know issue is the old npm may not work correctly with [version definition like '^3.1.0'](https://travis-ci.org/carlosaml/grunt-redact/jobs/58587889)
